### PR TITLE
Added Docker Compose files to deploy applications to Azure Web App (MOVECLOUD-T002 Solution)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 version: "3.4"
 services:
   api:
-    image: ghcr.io/mrsmitty/fabrikam-api:latest
+    image: ghcr.io/<yourgithubaccount>/fabrikam-api:latest
     ports:
       - "3001:3001"
 
   web:
-    image: ghcr.io/mrsmitty/fabrikam-web:latest
+    image: ghcr.io/<yourgithubaccount>/fabrikam-web:latest
     depends_on:
-      - api
+        - api
     environment:
-      CONTENT_API_URL: http://api:3001
+        CONTENT_API_URL: http://api:3001
     ports:
-      - "3000:80"
+        - "3000:80"       


### PR DESCRIPTION


# Instructions to Fix the exercise
Added a new docker-compose file (docker-compose) to configure the multi-container web application. To deploy this file, update the name of the container registry and change the CosmosDB connection string

```powershell
$studentprefix = "your abbreviation here"
$resourcegroupName = "fabmedical-rg-" + $studentprefix
$webappName = "fabmedical-web-" + $studentprefix

$ghpat=Read-Host -Prompt "Github Personal Access Token"

az webapp config container set `
--docker-registry-server-password $ghpat `
--docker-registry-server-url https://ghcr.io `
--docker-registry-server-user notapplicable `
--multicontainer-config-file docker-compose-prod.yml `
--multicontainer-config-type COMPOSE `
--name $webappName `
--resource-group $resourcegroupName 
```

Linked to [AB#2](https://dev.azure.com/PaulSmithdale/5b720fb3-5e78-4813-b9ba-3913849a5868/_workitems/edit/2)