### PR TITLE
Updated deployment file to be used with GitHub Actions (CLOSELOOP-T002)

### DIFF
--- a/build.docker-compose.yml
+++ b/build.docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.4"
+services:
+  api:
+    build: ./content-api
+
+  web:
+    build: ./content-web

--- a/infrastructure/deploy-infrastructure.ps1
+++ b/infrastructure/deploy-infrastructure.ps1
@@ -1,39 +1,52 @@
-$studentprefix = "346713"
+param
+(
+    [string] $studentprefix = "tst"
+)
+
 $resourcegroupName = "fabmedical-rg-" + $studentprefix
 $cosmosDBName = "fabmedical-cdb-" + $studentprefix
 $webappName = "fabmedical-web-" + $studentprefix
 $planName = "fabmedical-plan-" + $studentprefix
-$appInsights = "fabmedicalai-" + $studentsuffix
 $location1 = "westeurope"
 $location2 = "northeurope"
+$appInsights = "fabmedicalai-" + $studentsuffix
 
-# Then create a CosmosDB
+#First create a group
+$rg = az group create --name $resourcegroupName --location $location1 | ConvertFrom-Json 
+
+#Then create a CosmosDB
 az cosmosdb create --name $cosmosDBName `
-    --resource-group $resourcegroupName `
-    --locations regionName=$location1 failoverPriority=0 isZoneRedundant=False `--locations regionName=$location2 failoverPriority=1 isZoneRedundant=True `
-    --enable-multiple-write-locations `
-    --kind MongoDB
+--resource-group $resourcegroupName `
+--locations regionName=$location1 failoverPriority=0 isZoneRedundant=False `
+--locations regionName=$location2 failoverPriority=1 isZoneRedundant=True `
+--enable-multiple-write-locations `
+--kind MongoDB
 
 #Create a Azure App Service Plan
-az appservice plan create --name $planName `
-    --resource-group $resourcegroupName `
-    --sku S1 `
-    --is-linux
+az appservice plan create --name $planName --resource-group $resourcegroupName --sku S1 --is-linux
+
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_URL="https://ghcr.io" --name $($webappName) --resource-group $($resourcegroupName) 
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_USERNAME="notapplicable" --name $($webappName) --resource-group $($resourcegroupName) 
+az webapp config appsettings set --settings DOCKER_REGISTRY_SERVER_PASSWORD="$($env:CR_PAT)" --name $($webappName) --resource-group $($resourcegroupName) 
+
 
 #Create a Azure Web App with NGINX container
-az webapp create --resource-group $resourcegroupName `
-    --plan $planName `
-    --name $webappName `
-    -i nginx
+az webapp create `
+--multicontainer-config-file docker-compose.yml `
+--multicontainer-config-type COMPOSE `
+--name $($webappName) `
+--resource-group $($resourcegroupName) `
+--plan $($planName)
 
-    
+az webapp config container set `
+--docker-registry-server-password $($env:CR_PAT) `
+--docker-registry-server-url https://ghcr.io `
+--docker-registry-server-user notapplicable `
+--multicontainer-config-file docker-compose.yml `
+--multicontainer-config-type COMPOSE `
+--name $($webappName) `
+--resource-group $resourcegroupName 
+
 az extension add --name application-insights
-$ai = az monitor app-insights component create `
-    --app $appInsights `
-    --location $location1 `
-    --kind web `
-    -g $resourcegroupName `
-    --application-type web `
-    --retention-time 120 | ConvertFrom-Json
+az monitor app-insights component create --app $appInsights --location $location1 --kind web -g $resourcegroupName --application-type web --retention-time 120
 
-Write-Host "AI Instrumentation Key=$($ai.instrumentationKey)"


### PR DESCRIPTION

# Instructions to Fix the exercise

Modified the deployment script to have the prefix as a parameter and added the GitHub Secret environment variable instead of a local variable. To run the deployment locally, add a environment variable first that contains the GitHub Personal Access Token to pull images from the GitHub Container Registry


```PowerShell
# Personal Access Token should be pre-configured by setup.
# $env:CR_PAT="Your Pat Here" 
./infrastructure/deploy-infrastructure.ps1
```